### PR TITLE
Avoid multiple definitions of CLOCK_REALTIME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ a.out
 autom4te.cache
 darkstat-*
 hex-ify
+hex-ify.DSYM/
 c-ify
+c-ify.DSYM/
 config.h
 config.h.in
 config.log

--- a/now.c
+++ b/now.c
@@ -30,9 +30,11 @@
 #  include <mach/mach.h>
 #  include <mach/mach_time.h>
 
+#  ifndef CLOCK_REALTIME
    typedef int clockid_t;
 #  define CLOCK_REALTIME 0
 #  define CLOCK_MONOTONIC 1
+#  endif
 
    static uint64_t mono_first = 0;
 


### PR DESCRIPTION
This breaks macOS 11 build otherwise

Other than that it's innocuous (it won't break anything on any other platform since it's purely checking for the symbol already being defined and not redefining it).

I've also added a couple of patterns to `.gitignore` which correspond to build artifacts on macOS.