### PR TITLE
[WIP] openbsd: stats from pf

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -30,6 +30,8 @@ acct.c		\
 addr.c		\
 bsd.c		\
 cap.c		\
+cache.c		\
+pf.c		\
 conv.c		\
 darkstat.c	\
 daylog.c	\
@@ -159,10 +161,13 @@ addr.o: addr.c addr.h
 bsd.o: bsd.c bsd.h config.h cdefs.h
 cap.o: cap.c acct.h cdefs.h cap.h config.h conv.h decode.h addr.h err.h \
  hosts_db.h linktypes.h localip.h now.h opt.h queue.h str.h
+cache.o: cache.c cache.h
+pf.o: pf.c pf.h acct.h cdefs.h config.h conv.h decode.h addr.h err.h \
+ hosts_db.h localip.h now.h opt.h queue.h str.h cache.h
 conv.o: conv.c conv.h err.h cdefs.h
 darkstat.o: darkstat.c acct.h cap.h cdefs.h config.h conv.h daylog.h \
- graph_db.h db.h dns.h err.h hosts_db.h addr.h http.h localip.h ncache.h \
- now.h pidfile.h str.h
+ graph_db.h db.h dns.h err.h hosts_db.h addr.h http.h localip.h \
+ ncache.h now.h pidfile.h str.h pf.h
 daylog.o: daylog.c cdefs.h err.h daylog.h graph_db.h str.h now.h
 db.o: db.c err.h cdefs.h hosts_db.h addr.h graph_db.h db.h
 decode.o: decode.c cdefs.h decode.h addr.h err.h opt.h

--- a/acct.c
+++ b/acct.c
@@ -174,7 +174,7 @@ void acct_for(const struct pktsummary * const sm,
 #endif
 
    /* Totals. */
-   acct_total_packets++;
+   acct_total_packets += sm->packets;
    acct_total_bytes += sm->len;
 
    /* Graphs. */

--- a/cache.c
+++ b/cache.c
@@ -1,0 +1,208 @@
+/* $OpenBSD: cache.c,v 1.8 2019/01/17 05:56:29 tedu Exp $ */
+/*
+ * Copyright (c) 2001, 2007 Can Erkin Acar <canacar@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifdef __OpenBSD__
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#include <net/if.h>
+#include <netinet/in.h>
+
+#include <netinet/tcp_fsm.h>
+#ifdef TEST_COMPAT
+#include "pfvarmux.h"
+#else
+#include <net/pfvar.h>
+#endif
+#include <arpa/inet.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <assert.h>
+
+#include "cache.h"
+
+/* prototypes */
+void update_state(struct sc_ent *, struct pfsync_state *);
+struct sc_ent *cache_state(struct pfsync_state *);
+static __inline int sc_cmp(struct sc_ent *s1, struct sc_ent *s2);
+
+/* initialize the tree and queue */
+RB_HEAD(sc_tree, sc_ent) sctree;
+TAILQ_HEAD(sc_queue, sc_ent) scq1, scq2, scq_free;
+RB_GENERATE(sc_tree, sc_ent, tlink, sc_cmp)
+
+struct sc_queue *scq_act = NULL;
+struct sc_queue *scq_exp = NULL;
+
+int cache_max = 0;
+int cache_size = 0;
+
+struct sc_ent *sc_store = NULL;
+
+/* preallocate the cache and insert into the 'free' queue */
+int
+cache_init(int max)
+{
+	int n;
+	static int initialized = 0;
+
+	if (max < 0 || initialized)
+		return (1);
+
+	if (max == 0) {
+		sc_store = NULL;
+	} else {
+		sc_store = reallocarray(NULL, max, sizeof(struct sc_ent));
+		if (sc_store == NULL)
+			return (1);
+	}
+
+	RB_INIT(&sctree);
+	TAILQ_INIT(&scq1);
+	TAILQ_INIT(&scq2);
+	TAILQ_INIT(&scq_free);
+
+	scq_act = &scq1;
+	scq_exp = &scq2;
+
+	for (n = 0; n < max; n++)
+		TAILQ_INSERT_HEAD(&scq_free, sc_store + n, qlink);
+
+	cache_size = cache_max = max;
+	initialized++;
+
+	return (0);
+}
+
+void
+update_state(struct sc_ent *prev, struct pfsync_state *new)
+{
+	assert (prev != NULL && new != NULL);
+
+	u_int64_t bytes[2] = { COUNTER(new->bytes[0]), COUNTER(new->bytes[1]) };
+	prev->bytes_delta[0] = bytes[0] - prev->bytes[0];
+	prev->bytes_delta[1] = bytes[1] - prev->bytes[1];
+	prev->bytes[0] = bytes[0];
+	prev->bytes[1] = bytes[1];
+
+	u_int64_t packets[2] = { COUNTER(new->packets[0]), COUNTER(new->packets[1]) };
+	prev->packets_delta[0] = packets[0] - prev->packets[0];
+	prev->packets_delta[1] = packets[1] - prev->packets[1];
+	prev->packets[0] = packets[0];
+	prev->packets[1] = packets[1];
+}
+
+void
+add_state(struct pfsync_state *st)
+{
+	struct sc_ent *ent;
+	assert(st != NULL);
+
+	if (cache_max == 0)
+		return;
+
+	if (TAILQ_EMPTY(&scq_free))
+		return;
+
+	ent = TAILQ_FIRST(&scq_free);
+	TAILQ_REMOVE(&scq_free, ent, qlink);
+
+	cache_size--;
+
+	ent->id = st->id;
+	ent->creatorid = st->creatorid;
+	ent->bytes[0] = COUNTER(st->bytes[0]);
+	ent->bytes[1] = COUNTER(st->bytes[1]);
+	ent->packets[0] = COUNTER(st->packets[0]);
+	ent->packets[1] = COUNTER(st->packets[1]);
+
+	RB_INSERT(sc_tree, &sctree, ent);
+	TAILQ_INSERT_HEAD(scq_act, ent, qlink);
+}
+
+/* must be called only once for each state before cache_endupdate */
+struct sc_ent *
+cache_state(struct pfsync_state *st)
+{
+	struct sc_ent ent, *old;
+
+	if (cache_max == 0)
+		return (NULL);
+
+	ent.id = st->id;
+	ent.creatorid = st->creatorid;
+	old = RB_FIND(sc_tree, &sctree, &ent);
+
+	if (old == NULL) {
+		add_state(st);
+		return (NULL);
+	}
+
+	if (COUNTER(st->bytes[0]) < old->bytes[0] || COUNTER(st->bytes[1]) < old->bytes[1])
+		return (NULL);
+
+	update_state(old, st);
+
+	/* move to active queue */
+	TAILQ_REMOVE(scq_exp, old, qlink);
+	TAILQ_INSERT_HEAD(scq_act, old, qlink);
+
+	return (old);
+}
+
+/* remove the states that are not updated in this cycle */
+void
+cache_endupdate(void)
+{
+	struct sc_queue *tmp;
+	struct sc_ent *ent;
+
+	while (! TAILQ_EMPTY(scq_exp)) {
+		ent = TAILQ_FIRST(scq_exp);
+		TAILQ_REMOVE(scq_exp, ent, qlink);
+		RB_REMOVE(sc_tree, &sctree, ent);
+		TAILQ_INSERT_HEAD(&scq_free, ent, qlink);
+		cache_size++;
+	}
+
+	tmp = scq_act;
+	scq_act = scq_exp;
+	scq_exp = tmp;
+}
+
+static __inline int
+sc_cmp(struct sc_ent *a, struct sc_ent *b)
+{
+	if (a->id > b->id)
+		return (1);
+	if (a->id < b->id)
+		return (-1);
+	if (a->creatorid > b->creatorid)
+		return (1);
+	if (a->creatorid < b->creatorid)
+		return (-1);
+	return (0);
+}
+
+#endif
+
+/* vim:set ts=3 sw=3 tw=78 expandtab: */

--- a/cache.h
+++ b/cache.h
@@ -1,0 +1,49 @@
+/* $OpenBSD: cache.h,v 1.6 2019/01/17 05:56:29 tedu Exp $ */
+/*
+ * Copyright (c) 2001, 2007 Can Erkin Acar <canacar@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _CACHE_H_
+#define _CACHE_H_
+
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <netinet/tcp_fsm.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/queue.h>
+#include <sys/tree.h>
+#include <net/pfvar.h>
+
+struct sc_ent {
+	RB_ENTRY(sc_ent)    tlink;
+	TAILQ_ENTRY(sc_ent) qlink;
+	u_int64_t	    id;
+	u_int32_t	    creatorid;
+	u_int64_t	    bytes[2];
+	u_int64_t	    bytes_delta[2];
+	u_int64_t	    packets[2];
+	u_int64_t	    packets_delta[2];
+};
+
+int cache_init(int);
+void cache_endupdate(void);
+struct sc_ent *cache_state(struct pfsync_state *);
+extern int cache_max, cache_size;
+
+#define COUNTER(c) ((((u_int64_t) ntohl(c[0]))<<32) + ntohl(c[1]))
+
+#endif

--- a/cap.c
+++ b/cap.c
@@ -391,6 +391,7 @@ static void callback(u_char *user,
    if (opt_want_hexdump)
       hexdump(pdata, pheader->caplen, iface->linkhdr);
    memset(&sm, 0, sizeof(sm));
+   sm.packets = 1;
    if (iface->linkhdr->decoder(pheader, pdata, &sm))
       acct_for(&sm, &iface->local_ips);
 }

--- a/decode.h
+++ b/decode.h
@@ -27,7 +27,8 @@
 struct pktsummary {
    /* Fields are in host byte order (except IPs) */
    struct addr src, dst;
-   uint16_t len;
+   uint64_t packets;
+   uint64_t len;
    uint8_t proto; /* IPPROTO_INVALID means don't do proto accounting */
    uint8_t tcp_flags;           /* only for TCP */
    uint16_t src_port, dst_port; /* only for TCP, UDP */

--- a/pf.c
+++ b/pf.c
@@ -1,0 +1,209 @@
+/* darkstat 3
+ * copyright (c) 2001-2014 Emil Mikulic.
+ *
+ * pf.c: read pf states, and hand them off to decode and acct.
+ *
+ * You may use, modify and redistribute this file under the terms of the
+ * GNU General Public License version 2. (see COPYING.GPL)
+ */
+
+#ifdef __OpenBSD__
+
+#include "pf.h"
+#include "acct.h"
+#include "cdefs.h"
+#include "config.h"
+#include "conv.h"
+#include "decode.h"
+#include "err.h"
+#include "hosts_db.h"
+#include "localip.h"
+#include "now.h"
+#include "opt.h"
+#include "queue.h"
+#include "str.h"
+#include "cache.h"
+
+#include <sys/ioctl.h>
+#include <net/pfvar.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#define MIN_NUM_STATES 1024
+#define NUM_STATE_INC  1024
+
+#define DEFAULT_CACHE_SIZE 10000
+
+struct pfsync_state *state_buf = NULL;
+size_t state_buf_len = 0;
+size_t num_states = 0;
+
+int pf_dev = -1;
+
+struct local_ips local_ips;
+
+void pfsync_start(void) {
+   struct str *ifs = str_make();
+   str_appendn(ifs, "", 1); /* NUL terminate */
+   {
+      size_t _;
+      str_extract(ifs, &_, &title_interfaces);
+   }
+
+	pf_dev = open("/dev/pf", O_RDONLY);
+	if (pf_dev == -1) {
+      errx(1, "pfsync_start");
+   }
+
+   if (cache_init(1<<16)) {
+      errx(1, "pfsync_start: cache_init");
+   }
+
+   // FIXME: initialize ip addresses based on egress, by default?
+   localip_init(&local_ips);
+}
+
+void pfsync_fd_set(fd_set *read_set, int *max_fd,
+   struct timeval *timeout, int *need_timeout) {
+   assert(*need_timeout == 0); /* we're first to get a shot at the fd_set */
+
+   *need_timeout = 1;
+   timeout->tv_sec = 0;
+   timeout->tv_usec = 1000;
+}
+
+void
+alloc_buf(size_t ns)
+{
+	size_t len;
+
+	if (ns < MIN_NUM_STATES)
+		ns = MIN_NUM_STATES;
+
+	len = ns;
+
+	if (len >= state_buf_len) {
+		len += NUM_STATE_INC;
+		state_buf = reallocarray(state_buf, len,
+		    sizeof(struct pfsync_state));
+		if (state_buf == NULL)
+			errx(1, "realloc");
+		state_buf_len = len;
+	}
+}
+
+void pfsync_handle_state(struct pfsync_state * s, struct sc_ent * ent) {
+   int afto, dir;
+
+#undef v4
+
+   // FIXME: support ipv6
+   if (s->key[0].af != AF_INET || s->key[1].af != AF_INET) {
+      return;
+   }
+
+   u_int64_t bytes_delta[2];
+   u_int64_t packets_delta[2];
+   if (ent != NULL) {
+      bytes_delta[0] = ent->bytes_delta[0];
+      bytes_delta[1] = ent->bytes_delta[1];
+      packets_delta[0] = ent->packets_delta[0];
+      packets_delta[1] = ent->packets_delta[1];
+   } else {
+      bytes_delta[0] = COUNTER(s->bytes[0]);
+      bytes_delta[1] = COUNTER(s->bytes[1]);
+      packets_delta[0] = COUNTER(s->packets[0]);
+      packets_delta[1] = COUNTER(s->packets[1]);
+   }
+
+   afto = s->key[PF_SK_STACK].af == s->key[PF_SK_WIRE].af ? 0 : 1;
+   dir = afto ? PF_OUT : s->direction;
+
+   struct pktsummary sm;
+   memset(&sm, 0, sizeof(sm));
+
+   sm.src.family = IPv4;
+   sm.dst.family = IPv4;
+   sm.proto = s->proto;
+
+   sm.len = (dir == PF_OUT) ? bytes_delta[0] : bytes_delta[1];
+   sm.packets = (dir == PF_OUT) ? packets_delta[0] : packets_delta[1];
+
+   if (sm.len > 0) {
+      struct pfsync_state_key *ks = &s->key[afto ? PF_SK_STACK : PF_SK_WIRE];
+      sm.src.ip.v4 = ks->addr[1].pfa.v4.s_addr;
+      sm.src_port = ntohs(ks->port[1]);
+
+      sm.dst.ip.v4 = ks->addr[0].pfa.v4.s_addr;
+      sm.dst_port = ntohs(ks->port[0]);
+
+      acct_for(&sm, &local_ips);
+   }
+
+   sm.len = (dir == PF_OUT) ? bytes_delta[1] : bytes_delta[0];
+   sm.packets = (dir == PF_OUT) ? packets_delta[1] : packets_delta[0];
+   if (sm.len > 0) {
+      struct pfsync_state_key *ks = &s->key[PF_SK_STACK];
+      sm.src.ip.v4 = ks->addr[0].pfa.v4.s_addr;
+      sm.src_port = ntohs(ks->port[0]);
+
+      sm.dst.ip.v4 = ks->addr[1].pfa.v4.s_addr;
+      sm.dst_port = ntohs(ks->port[1]);
+
+      acct_for(&sm, &local_ips);
+   }
+}
+
+int pfsync_poll(void) {
+   int n;
+	struct pfioc_states ps;
+
+   ps.ps_len = 0;
+   ps.ps_states = NULL;
+
+   if (ioctl(pf_dev, DIOCGETSTATES, &ps) == -1) {
+      errx(1, "DIOCGETSTATES");
+   }
+
+	for (;;) {
+		size_t sbytes = state_buf_len * sizeof(struct pfsync_state);
+
+		ps.ps_len = sbytes;
+		ps.ps_states = state_buf;
+
+		if (ioctl(pf_dev, DIOCGETSTATES, &ps) == -1) {
+			errx(1, "DIOCGETSTATES");
+		}
+		num_states = ps.ps_len / sizeof(struct pfsync_state);
+
+		if (ps.ps_len < sbytes)
+			break;
+
+		alloc_buf(num_states);
+	}
+
+   for (n = 0; n < num_states; n++) {
+      struct sc_ent *ent = cache_state(state_buf + n);
+      if (ent != NULL) {
+         pfsync_handle_state(state_buf + n, ent);
+      }
+   }
+   cache_endupdate();
+
+   return 1;
+}
+
+void pfsync_stop(void) {
+   int ret = close(pf_dev);
+   if (ret == -1) {
+      errx(1, "pfsync_stop: close");
+   }
+
+   localip_free(&local_ips);
+}
+
+#endif
+
+/* vim:set ts=3 sw=3 tw=78 expandtab: */

--- a/pf.c
+++ b/pf.c
@@ -94,6 +94,19 @@ alloc_buf(size_t ns)
 	}
 }
 
+int state_simple_idx(struct pfsync_state *s, int idx) {
+  struct pfsync_state_key *sk, *nk;
+
+  sk = &s->key[PF_SK_STACK];
+  nk = &s->key[PF_SK_WIRE];
+
+  if (sk->af != nk->af || PF_ANEQ(&sk->addr[idx], &nk->addr[idx], sk->af) ||
+      sk->port[idx] != nk->port[idx] || sk->rdomain != nk->rdomain) {
+    return 0;
+  }
+  return 1;
+}
+
 void pfsync_handle_state(struct pfsync_state * s, struct sc_ent * ent) {
    int afto, dir;
 
@@ -101,6 +114,9 @@ void pfsync_handle_state(struct pfsync_state * s, struct sc_ent * ent) {
 
    // FIXME: support ipv6
    if (s->key[0].af != AF_INET || s->key[1].af != AF_INET) {
+      return;
+   }
+   if (!state_simple_idx(s, 0) || !state_simple_idx(s, 1)) {
       return;
    }
 

--- a/pf.h
+++ b/pf.h
@@ -1,0 +1,17 @@
+/* darkstat 3
+ * copyright (c) 2001-2014 Emil Mikulic.
+ *
+ * pf.h: interface to OpenBSD pf.
+ */
+
+#include <sys/types.h> /* OpenBSD needs this before select */
+#include <sys/time.h> /* FreeBSD 4 needs this for struct timeval */
+#include <sys/select.h>
+
+void pfsync_start(void);
+void pfsync_fd_set(fd_set *read_set, int *max_fd,
+   struct timeval *timeout, int *need_timeout);
+int pfsync_poll(void);
+void pfsync_stop(void);
+
+/* vim:set ts=3 sw=3 tw=78 expandtab: */


### PR DESCRIPTION
While trying to monitor traffic on OpenBSD router box with `darkstat`, I observed that `darkstat` cannot account traffic accurately when there's a large traffic, because of packet `pcap` packet drop. For example, openbsd `pcap` drops about 1/3 packets on ~1gbps which makes accounting rather inaccurate.
To overcome the issue, I tried to capture number of bytes/packets from `pf` instead of `pcap`. It seems working on my environment and I wanted share the patch with others :)

Notes
- `cache.c` and `pf.c` are largely borrowed from openbsd source tree.
- pf should be enabled to make it work.
- It requires to set `-l` flag to work property, as it cannot detect local interface address.
- It does not handle ipv6 states.