### PR TITLE
Fix compiling with 64bit time_t (e.g. MIPS)

### DIFF
--- a/graph_db.c
+++ b/graph_db.c
@@ -199,8 +199,8 @@ void graph_rotate(void) {
 
    if (t < last_real) {
       verbosef("graph_db: realtime went backwards! "
-               "(from %ld to %ld, offset is %ld)",
-               last_real, t, td);
+               "(from %lld to %lld, offset is %lld)",
+               (lld)last_real, (lld)t, (lld)td);
       graph_resync(t);
       return;
    }


### PR DESCRIPTION
Fix warnings on systems with 64bit time_t
```
graph_db.c:201:16: error: format '%ld' expects argument of type 'long int', but argument 2 has type 'time_t' {aka 'long long int'} [-Werror=format=]
  201 |       verbosef("graph_db: realtime went backwards! "
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  202 |                "(from %ld to %ld, offset is %ld)",
  203 |                last_real, t, td);
      |                ~~~~~~~~~
      |                |
      |                time_t {aka long long int}
```