### PR TITLE
Implement individual statistics for peers of each host

### DIFF
--- a/acct.c
+++ b/acct.c
@@ -372,6 +372,22 @@ void acct_for(const struct pktsummary * const sm,
                       PEER_PORT_TCP, PEER_PORT_TCP_PEER,
                       sm->dst_port, sm->src_port);
       }
+
+      /* Use host name from decode if present
+       * If there is already a name from dns lookup replace it */
+      if (hd && !hd->u.host.dns_from_decode &&
+          sm->hostname && sm->hostname_length) {
+         char *dns = xmalloc(sm->hostname_length + 1);
+         memcpy(dns, sm->hostname, sm->hostname_length);
+         dns[sm->hostname_length] = 0;
+
+         if (hd->u.host.dns)
+            free(hd->u.host.dns);
+            
+         hd->u.host.dns_from_decode = 1;
+         hd->u.host.dns = dns;
+      }
+
       break;
 
    case IPPROTO_UDP:

--- a/acct.c
+++ b/acct.c
@@ -310,6 +310,22 @@ void acct_for(const struct pktsummary * const sm,
       }
    }
 
+   if (opt_want_peers && sm->proto != IPPROTO_INVALID &&
+       sm->proto != IPPROTO_TCP && sm->proto != IPPROTO_UDP) {
+      if (hs) {
+         struct bucket *p = host_get_peer(hs, &(sm->dst));
+         struct bucket *ps = peer_get_ip_proto(p, sm->proto);
+         ps->out   += sm->len;
+         ps->total += sm->len;
+      }
+      if (hd) {
+         struct bucket *p = host_get_peer(hd, &(sm->src));
+         struct bucket *pd = peer_get_ip_proto(p, sm->proto);
+         pd->in    += sm->len;
+         pd->total += sm->len;
+      }
+   }
+
    if (opt_ports_max == 0) return; /* skip ports accounting */
 
    /* Ports. */

--- a/darkstat.c
+++ b/darkstat.c
@@ -104,6 +104,12 @@ static void cb_no_dns(const char *arg _unused_) { opt_want_dns = 0; }
 int opt_want_macs = 1;
 static void cb_no_macs(const char *arg _unused_) { opt_want_macs = 0; }
 
+int opt_want_peers = 0;
+static void cb_peers(const char *arg _unused_) { opt_want_peers = 1; }
+
+int opt_want_ports = 1;
+static void cb_no_ports(const char *arg _unused_) { opt_want_ports = 0; }
+
 int opt_want_lastseen = 1;
 static void cb_no_lastseen(const char *arg _unused_) { opt_want_lastseen = 0; }
 
@@ -165,6 +171,14 @@ unsigned int opt_highest_port = 65535;
 static void cb_highest_port(const char *arg)
 { opt_highest_port = parsenum(arg, 65535); }
 
+unsigned int opt_peers_max = 1000;
+static void cb_peers_max(const char *arg)
+{ opt_peers_max = parsenum(arg, 65536); }
+
+unsigned int opt_peers_keep = 500;
+static void cb_peers_keep(const char *arg)
+{ opt_peers_keep = parsenum(arg, 65536); }
+
 int opt_wait_secs = -1;
 static void cb_wait_secs(const char *arg)
 { opt_wait_secs = (int)parsenum(arg, 0); }
@@ -204,6 +218,8 @@ static struct cmdline_arg cmdline_args[] = {
    {"--no-promisc",   NULL,              cb_no_promisc,   0},
    {"--no-dns",       NULL,              cb_no_dns,       0},
    {"--no-macs",      NULL,              cb_no_macs,      0},
+   {"--no-ports",     NULL,              cb_no_ports,     0},
+   {"--peers",        NULL,              cb_peers,        0},
    {"--no-lastseen",  NULL,              cb_no_lastseen,  0},
    {"--chroot",       "dir",             cb_chroot,       0},
    {"--user",         "username",        cb_user,         0},
@@ -216,6 +232,8 @@ static struct cmdline_arg cmdline_args[] = {
    {"--ports-max",    "count",           cb_ports_max,    0},
    {"--ports-keep",   "count",           cb_ports_keep,   0},
    {"--highest-port", "port",            cb_highest_port, 0},
+   {"--peers-max",    "count",           cb_peers_max,    0},
+   {"--peers-keep",   "count",           cb_peers_keep,   0},
    {"--wait",         "secs",            cb_wait_secs,    0},
    {"--hexdump",      NULL,              cb_hexdump,      0},
    {"--version",      NULL,              cb_version,      0},

--- a/decode.h
+++ b/decode.h
@@ -33,6 +33,8 @@ struct pktsummary {
    uint16_t src_port, dst_port; /* only for TCP, UDP */
    uint8_t src_mac[ETHER_ADDR_LEN], /* only for Ethernet */
            dst_mac[ETHER_ADDR_LEN]; /* only for Ethernet */
+   const char*    hostname;
+   uint8_t        hostname_length;
 };
 
 struct pcap_pkthdr; /* from pcap.h */
@@ -52,6 +54,26 @@ struct linkhdr {
 
 const struct linkhdr *getlinkhdr(const int linktype);
 int getsnaplen(const struct linkhdr *lh);
+
+#define TLS_HDR_LEN 5
+#define TLS_HDR_TYPE        0
+#define TLS_HDR_PROTO_MAJOR 1
+#define TLS_HDR_PROTO_MINOR 2
+#define TLS_HDR_DATA_LENGTH 3
+
+#define TLS_HDSHK_TYPE           5
+#define TLS_HDSHK_LENGTH         6
+#define TLS_HDSHK_PROTO_MAJOR    9
+#define TLS_HDSHK_PROTO_MINOR    10
+#define TLS_HDSHK_RANDOM         11
+#define TLS_HDSHK_SESSION_LENGTH 43
+#define TLS_HDSHK_SESSION        44
+
+#define TLS_CONTENT_TYPE_HANDSHAKE  22
+#define TLS_HANDSHAKE_TYPE_HELLO    1
+
+#define TLS_EXTENSION_HOST          0
+#define TLS_SNI_TYPE_HOST           0
 
 #endif /* __DARKSTAT_DECODE_H */
 /* vim:set ts=3 sw=3 tw=78 expandtab: */

--- a/graph_db.c
+++ b/graph_db.c
@@ -199,8 +199,8 @@ void graph_rotate(void) {
 
    if (t < last_real) {
       verbosef("graph_db: realtime went backwards! "
-               "(from %ld to %ld, offset is %ld)",
-               last_real, t, td);
+               "(from %lld to %lld, offset is %lld)",
+               (lld)last_real, (lld)t, (lld)td);
       graph_resync(t);
       return;
    }

--- a/hosts_db.c
+++ b/hosts_db.c
@@ -698,6 +698,8 @@ format_row_peer(struct str *buf, const struct bucket *b)
       lines += p->ports[PEER_PORT_TCP]->count;
    if (p->ports[PEER_PORT_UDP])
       lines += p->ports[PEER_PORT_UDP]->count;
+   if (p->ip_protos)
+      lines += p->ip_protos->count;
 
    if (lines > 1) {
       /* Summary line for multiple ports

--- a/hosts_db.c
+++ b/hosts_db.c
@@ -242,6 +242,7 @@ make_func_host(const void *key)
    MAKE_BUCKET(b, h, host);
    h->addr = CASTKEY(struct addr);
    h->dns = NULL;
+   h->dns_from_decode = 0;
    h->last_seen_mono = 0;
    memset(&h->mac_addr, 0, sizeof(h->mac_addr));
    h->ports_tcp = NULL;

--- a/hosts_db.h
+++ b/hosts_db.h
@@ -29,6 +29,7 @@ struct host {
    struct hashtable *ports_udp_remote;
    struct hashtable *ip_protos;
    struct hashtable *peers;
+   uint8_t  dns_from_decode;
 };
 
 struct port_tcp {

--- a/hosts_db.h
+++ b/hosts_db.h
@@ -28,6 +28,7 @@ struct host {
    struct hashtable *ports_udp;
    struct hashtable *ports_udp_remote;
    struct hashtable *ip_protos;
+   struct hashtable *peers;
 };
 
 struct port_tcp {
@@ -43,6 +44,25 @@ struct ip_proto {
    uint8_t proto;
 };
 
+enum peer_port_tables {
+   PEER_PORT_TCP = 0,
+   PEER_PORT_TCP_PEER = 1,
+   PEER_PORT_UDP = 2,
+   PEER_PORT_UDP_PEER = 3,
+   PEER_PORT_TABLES = 4
+};
+
+struct peer {
+   struct addr addr;
+   struct hashtable *ports[PEER_PORT_TABLES];
+};
+
+struct peer_port {
+   uint16_t port;
+   uint16_t port_peer;
+   uint8_t  hidden;
+};
+
 struct bucket {
    struct bucket *next;
    uint64_t in, out, total;
@@ -51,6 +71,8 @@ struct bucket {
       struct port_tcp port_tcp;
       struct port_udp port_udp;
       struct ip_proto ip_proto;
+      struct peer peer;
+      struct peer_port peer_port;
    } u;
 };
 
@@ -74,6 +96,9 @@ struct bucket *host_get_port_udp(struct bucket *host, const uint16_t port);
 struct bucket *host_get_port_udp_remote(struct bucket *host,
                                         const uint16_t port);
 struct bucket *host_get_ip_proto(struct bucket *host, const uint8_t proto);
+struct bucket *host_get_peer(struct bucket *host, const struct addr *const a);
+struct bucket *peer_find_port(struct hashtable *table, uint16_t port);
+struct bucket *peer_get_port(struct hashtable **table, uint16_t port);
 
 /* Web pages. */
 struct str *html_hosts(const char *uri, const char *query);

--- a/hosts_db.h
+++ b/hosts_db.h
@@ -55,6 +55,7 @@ enum peer_port_tables {
 struct peer {
    struct addr addr;
    struct hashtable *ports[PEER_PORT_TABLES];
+   struct hashtable *ip_protos;
 };
 
 struct peer_port {
@@ -99,6 +100,7 @@ struct bucket *host_get_ip_proto(struct bucket *host, const uint8_t proto);
 struct bucket *host_get_peer(struct bucket *host, const struct addr *const a);
 struct bucket *peer_find_port(struct hashtable *table, uint16_t port);
 struct bucket *peer_get_port(struct hashtable **table, uint16_t port);
+struct bucket *peer_get_ip_proto(struct bucket *peer, const uint8_t proto);
 
 /* Web pages. */
 struct str *html_hosts(const char *uri, const char *query);

--- a/opt.h
+++ b/opt.h
@@ -10,6 +10,8 @@ extern int opt_want_macs;
 extern int opt_want_hexdump;
 extern int opt_want_snaplen;
 extern int opt_wait_secs;
+extern int opt_want_peers;
+extern int opt_want_ports;
 
 /* Error/logging options. */
 extern int opt_want_verbose;
@@ -26,6 +28,8 @@ extern unsigned int opt_hosts_max;
 extern unsigned int opt_hosts_keep;
 extern unsigned int opt_ports_max;
 extern unsigned int opt_ports_keep;
+extern unsigned int opt_peers_max;
+extern unsigned int opt_peers_keep;
 
 /* Hosts output options. */
 extern int opt_want_lastseen;

--- a/static/style.css
+++ b/static/style.css
@@ -35,11 +35,14 @@ h1, h2, h3, h4, h5, h6
 table          { border-collapse: collapse; }
 td, th { border:1px solid #C0C0C0; padding:1px 5px 1px 5px; }
 td.num { text-align:right; }
+td.transparent { background: white; border: 0px; }
 th { background-color:#EFEFEF; font-weight: bold;
      padding-top:2px; padding-bottom:2px; }
 th a { color:black; border-bottom:1px dotted; }
 tr:nth-child(odd)  { background:#FFFFFF; }
 tr:nth-child(even) { background:#FAFAFA; }
+tr.odd  { background:#FFFFFF; }
+tr.even { background:#FAFAFA; }
 tr:hover { background:#EFEFEF; }
 body, td, th, p, input, textarea
                { font-family: Tahoma, Verdana, sans-serif;

--- a/str.c
+++ b/str.c
@@ -363,4 +363,19 @@ size_t str_len(const struct str * const buf) {
    return buf->len;
 }
 
+void
+str_printf_at(struct str *s, size_t pos, const char *format, ...)
+{
+   size_t len = s->len;
+
+   va_list va;
+   va_start(va, format);
+   if (pos < len) {
+      s->len = pos;
+      str_vappendf(s, format, va);
+      s->len = len;
+   }
+   va_end(va);
+}
+
 /* vim:set ts=3 sw=3 tw=78 expandtab: */

--- a/str.c
+++ b/str.c
@@ -373,7 +373,8 @@ str_printf_at(struct str *s, size_t pos, const char *format, ...)
    if (pos < len) {
       s->len = pos;
       str_vappendf(s, format, va);
-      s->len = len;
+      if (len > s->len)
+         s->len = len;
    }
    va_end(va);
 }

--- a/str.h
+++ b/str.h
@@ -65,5 +65,7 @@ struct str *length_of_time(const time_t t);
 ssize_t str_write(const struct str * const buf, const int fd);
 size_t str_len(const struct str * const buf);
 
+void str_printf_at(struct str *s, size_t pos, const char *format, ...);
+
 #endif  /* __DARKSTAT_STR_H */
 /* vim:set ts=3 sw=3 tw=78 expandtab: */


### PR DESCRIPTION
This patch implements collection of port statistics for each individual peer.
With this you can see all conections from any particular or to a particular destination.
Multiple ports on on side to the same port on the peer are summarized. Usually you are not interested in the diferent local ports used to connect to the same target, e.g. for fetching a web page.
At the first occurence of a packet we still do not know in which direction the connections goes, i.e. if the local port is client or server. Therefore a record for both port lists is created (local and peer) and local is marked as hidden in order to avoid duplicates in the output. If a new packet for the same local port is received and summarization on local ports will be performed and the peer port entry is marked as hidden instead.

The switch --peers activates collection of peer statistics
As with port statistics are redundant with this there is also
a new switch --no-ports to disable them