### PR TITLE
Added support multiple -l args

### DIFF
--- a/acct.c
+++ b/acct.c
@@ -37,8 +37,9 @@
 
 uint64_t acct_total_packets = 0, acct_total_bytes = 0;
 
-static int using_localnet4 = 0, using_localnet6 = 0;
-static struct addr localnet4, localmask4, localnet6, localmask6;
+static int total_localnets4 = 0, total_localnets6 = 0;
+static struct addr *localnets4 = NULL, *localmasks4 = NULL;
+static struct addr *localnets6 = NULL, *localmasks6 = NULL;
 
 /* Parse the net/mask specification into two IPs or die trying. */
 void
@@ -120,13 +121,19 @@ acct_init_localnet(const char *spec)
    /* Register the correct netmask and calculate the correct net.  */
    addr_mask(&localnet, &localmask);
    if (localnet.family == IPv6) {
-      using_localnet6 = 1;
-      localnet6 = localnet;
-      localmask6 = localmask;
+      j = total_localnets6 + 1;
+      localnets6 = xrealloc(localnets6, sizeof(*(localnets6)) * j);
+      localmasks6 = xrealloc(localmasks6, sizeof(*(localmasks6)) * j);
+      localnets6[total_localnets6] = localnet;
+      localmasks6[total_localnets6] = localmask;
+      total_localnets6++;
    } else {
-      using_localnet4 = 1;
-      localnet4 = localnet;
-      localmask4 = localmask;
+      j = total_localnets4 + 1;
+      localnets4 = xrealloc(localnets4, sizeof(*(localnets4)) * j);
+      localmasks4 = xrealloc(localmasks4, sizeof(*(localmasks4)) * j);
+      localnets4[total_localnets4] = localnet;
+      localmasks4[total_localnets4] = localmask;
+      total_localnets4++;
    }
 
    verbosef("local network address: %s", addr_to_str(&localnet));
@@ -135,14 +142,19 @@ acct_init_localnet(const char *spec)
 
 static int addr_is_local(const struct addr * const a,
                          const struct local_ips *local_ips) {
+   int i;
    if (is_localip(a, local_ips))
       return 1;
-   if (a->family == IPv4 && using_localnet4) {
-      if (addr_inside(a, &localnet4, &localmask4))
-         return 1;
-   } else if (a->family == IPv6 && using_localnet6) {
-      if (addr_inside(a, &localnet6, &localmask6))
-         return 1;
+   if (a->family == IPv4) {
+      for (i = 0; i < total_localnets4; i++) {
+         if (addr_inside(a, &localnets4[i], &localmasks4[i]))
+            return 1;
+      }
+   } else if (a->family == IPv6) {
+      for (i = 0; i < total_localnets6; i++) {
+         if (addr_inside(a, &localnets6[i], &localmasks6[i]))
+            return 1;
+      }
    }
    return 0;
 }

--- a/darkstat.c
+++ b/darkstat.c
@@ -193,7 +193,7 @@ static struct cmdline_arg cmdline_args[] = {
    {"-r",             "capfile",         cb_capfile,      0},
    {"-p",             "port",            cb_port,         0},
    {"-b",             "bindaddr",        cb_bindaddr,    -1},
-   {"-l",             "network/netmask", cb_local,        0},
+   {"-l",             "network/netmask", cb_local,       -1},
    {"--base",         "path",            cb_base,         0},
    {"--local-only",   NULL,              cb_local_only,   0},
    {"--snaplen",      "bytes",           cb_snaplen,      0},


### PR DESCRIPTION
As I pointed in https://github.com/emikulic/darkstat/issues/25#issuecomment-3094591084 here no way to specify multiple `-l` options now.

Here I added this feature.

I've tried to follow your style.